### PR TITLE
Tweak table for mobile

### DIFF
--- a/docs/css/hurley.css
+++ b/docs/css/hurley.css
@@ -26,6 +26,7 @@ input[type="number"] {
   font-size: 30px; }
 
 div#input table {
-  width: 400px; }
+  width: 100%;
+  max-width: 400px; }
   div#input table tr.inputrow td:first-child {
-    width: 300px; }
+    width: 80%; }

--- a/docs/js/Main.js
+++ b/docs/js/Main.js
@@ -5893,21 +5893,21 @@ var $author$project$Model$setUnmodifiedSwitchSets = F2(
 			{unmodifiedSwitchSets: a});
 	});
 var $elm$html$Html$table = _VirtualDom_node('table');
-var $author$project$Messages$tooltip_accessories = 'Total number of other keyboard accesories you own such as stand alone or spare PCBs, alternate plates, switch testers, etc.';
-var $author$project$Messages$tooltip_accessory_gbs = 'Total number of other keyboard accesories (spare PCBs, altenrate plates, switch testers, etc.) you currenlty have on order but have not yet recieved';
-var $author$project$Messages$tooltip_artisan_gbs = 'Total number of artisan keycaps you currenlty have on order but have not yet recieved';
+var $author$project$Messages$tooltip_accessories = 'Total number of other keyboard accessories you own such as stand-alone or spare PCBs, alternate plates, switch testers, etc.';
+var $author$project$Messages$tooltip_accessory_gbs = 'Total number of other keyboard accessories (spare PCBs, alternate plates, switch testers, etc.) you currently have on order but have not yet received';
+var $author$project$Messages$tooltip_artisan_gbs = 'Total number of artisan keycaps you currently have on order but have not yet received';
 var $author$project$Messages$tooltip_artisans = 'Total number of artisan keycaps you own. This does not include novelties.';
-var $author$project$Messages$tooltip_cable_gbs = 'Total number of \'fancy\' cables you currenlty have on order but have not yet recieved';
+var $author$project$Messages$tooltip_cable_gbs = 'Total number of \'fancy\' cables you currently have on order but have not yet received';
 var $author$project$Messages$tooltip_cables = 'Total number of \'fancy\' cables you own.';
-var $author$project$Messages$tooltip_deskpad_gbs = 'Total number of deskmats you currenlty have on order but have not yet recieved';
-var $author$project$Messages$tooltip_deskpads = 'Total number of deskmats you own.';
-var $author$project$Messages$tooltip_keyboard_gbs = 'Total number of keyboards you currenlty have on order but have not yet recieved.';
-var $author$project$Messages$tooltip_keyboards = 'Total number of keyboards you own. A keyboard is a PCB and whatever it is mounted to/on/in (whether assembled or not). Stand alone or extra PCBs are counted as accessories. Macropads and Num Pads are counted as keyboard kits; however, their switches and keycaps are not counted in their respective categories.';
-var $author$project$Messages$tooltip_keycap_gbs = 'Total number of sets of keycaps you currenlty have on order but have not yet recieved.';
+var $author$project$Messages$tooltip_deskpad_gbs = 'Total number of desk mats you currently have on order but have not yet received';
+var $author$project$Messages$tooltip_deskpads = 'Total number of desk mats you own.';
+var $author$project$Messages$tooltip_keyboard_gbs = 'Total number of keyboards you currently have on order but have not yet received.';
+var $author$project$Messages$tooltip_keyboards = 'Total number of keyboards you own. A keyboard is a PCB and whatever it is mounted to/on/in (whether assembled or not). Stand-alone or extra PCBs are counted as accessories. Macropads and Num Pads are counted as keyboard kits; however, their switches and keycaps are not counted in their respective categories.';
+var $author$project$Messages$tooltip_keycap_gbs = 'Total number of sets of keycaps you currently have on order but have not yet received.';
 var $author$project$Messages$tooltip_keycaps = 'Total number of keycaps sets you own. If you have multiple kits for the same set they are all counted as one set unless they can be used to fully kit multiple boards in which case they are counted as a number of sets equal to the number of boards they can fully kit simultaneously. Artisan Keycaps are counted as Accessories';
-var $author$project$Messages$tooltip_modified_switches = 'Total number of customized sets of switches that have been modified by you. Modified switch sets include thos that you have lubed, filmed or made other similar modifications to. Clipping switch pins does not count as a modification. If you make Frankenswitches (where you take components from one set of switches and use them to replace the components of another set of switches) both sets are considered modified if both sets have been reassembled. Each set of modified switches is counted as a single set regardless of the number of modifications made.';
-var $author$project$Messages$tooltip_switch_gbs = 'Total number of sets of switches you currenlty have on order but have not yet recieved.';
-var $author$project$Messages$tooltip_unmodified_switches = 'Total number of stock switch sets that you own. A set of switches sufficient to fill a normal sized board. Duplicate sets are counted if they were purchased separately or are used/intended to be used on separate boards.';
+var $author$project$Messages$tooltip_modified_switches = 'Total number of customized sets of switches that have been modified by you. Modified switch sets include those that you have lubed, filmed, or made other similar modifications to. Clipping switch pins does not count as a modification. If you make Frankenswitches (where you take components from one set of switches and use them to replace the components of another set of switches) both sets are considered modified if both sets have been reassembled. Each set of modified switches is counted as a single set regardless of the number of modifications made.';
+var $author$project$Messages$tooltip_switch_gbs = 'Total number of sets of switches you currently have on order but have not yet received.';
+var $author$project$Messages$tooltip_unmodified_switches = 'Total number of stock switch sets that you own. A set of switches sufficient to fill a normal-sized board. Duplicate sets are counted if they were purchased separately or are used/intended to be used on separate boards.';
 var $author$project$View$inputFields = A2(
 	$elm$html$Html$div,
 	_List_fromArray(

--- a/src/sass/hurley.sass
+++ b/src/sass/hurley.sass
@@ -33,8 +33,9 @@ input[type="number"]
 
 div#input
     table
-        width: 400px
+        width: 100%
+        max-width: 400px;
 
         tr.inputrow
             td:first-child
-                width: 300px
+                width: 80%

--- a/src/sass/hurley.sass
+++ b/src/sass/hurley.sass
@@ -34,7 +34,7 @@ input[type="number"]
 div#input
     table
         width: 100%
-        max-width: 400px;
+        max-width: 400px
 
         tr.inputrow
             td:first-child


### PR DESCRIPTION
Quick tiny style tweak that should help with the inputs on mobile. (CSS nerd here, but thank you for the perfect tiny project to start getting a feel for Elm! This is really cool.)

Before:
<img width="378" alt="Screen Shot 2021-04-22 at 8 41 28 PM" src="https://user-images.githubusercontent.com/1926679/115802565-262bb380-a3ad-11eb-88e4-24fa95a50cbf.png">


After:
<img width="377" alt="Screen Shot 2021-04-22 at 8 40 49 PM" src="https://user-images.githubusercontent.com/1926679/115802539-1c09b500-a3ad-11eb-8ebe-8fa779674e1a.png">